### PR TITLE
This should guard against user distraction

### DIFF
--- a/Args.cpp
+++ b/Args.cpp
@@ -106,8 +106,7 @@ void Args::parse(string line) {
     else if (key == "-user") { user = s; }
     else if (key == "-cpu") { cpu = s; }
     else if (key == "-time") { timeKernels = true; }
-    else if (key == "-device" || key == "-d") { device = stoi(s); }
-        else { device = 0; }
+    else if (key == "-device" || key == "-d") if (s.empty()) {device=0;} else {device=stoi(s);}
     if (cpu.empty()) { cpu = getHwName(device) + "-" + getBoardName(device) + "-" + str(device); }
     else if (key == "-dir") { dir = s; }
     else if (key == "-yield") { cudaYield = true; }


### PR DESCRIPTION
If -device|-d is not specified this default to zero which is the first gpu. With this mod if only -device|-d is specified without the gpu number, it also defaults to zero. But probably there you want to throw an error?